### PR TITLE
Give tab links an empty href attribute

### DIFF
--- a/layouts/taxonomy/tag.terms.html
+++ b/layouts/taxonomy/tag.terms.html
@@ -3,9 +3,15 @@
 <h1 id="primary-title">Tags</h1>
 
 <ul class="nav nav-tabs">
-  <li role="presentation"><a class="view-taglist">View all tags as list</a></li>
-  <li role="presentation" class="active"><a class="view-tagcloud">View all tags as cloud</a></li>
-  <li role="presentation"><a class="view-popular">View most popular tags</a></li>
+    <li role="presentation">
+        <a href="#" class="view-taglist">View all tags as list</a>
+    </li>
+    <li role="presentation" class="active">
+        <a href="#" class="view-tagcloud">View all tags as cloud</a>
+    </li>
+    <li role="presentation">
+        <a href="#" class="view-popular">View most popular tags</a>
+    </li>
 </ul>
 
 


### PR DESCRIPTION
When I hovered over these tabs with the mouse, the cursor icon was
incorrect. This fixes the problem and makes it clear that you can click
them.