### PR TITLE
Fix popular tags links

### DIFF
--- a/layouts/taxonomy/tag.terms.html
+++ b/layouts/taxonomy/tag.terms.html
@@ -26,10 +26,13 @@
 
 <div id="tag-popular">
 <ul>
-    {{ $data := .Data.Terms }}
+    {{ $data := .Data }}
     {{ range $key, $value := first 10 .Data.Terms.ByCount }}
     <li>
-        <a rel="tag" href="/{{ $data.Plural }}/{{ $value.Name | urlize }}">{{ $value.Name }} <span>{{$value.Count}}</span></a></li>
+        <a rel="tag" href="/{{ $data.Plural }}/{{ $value.Name | urlize }}">
+            {{ $value.Name }} <span>{{$value.Count}}</span>
+        </a>
+    </li>
     {{ end }}
 </ul>
 </div>


### PR DESCRIPTION
The links on the popular tags page weren't accurate. This fixes the
problem.