### PR TITLE
Use img srcset to serve high-res logos - PMT #107388

### DIFF
--- a/layouts/partials/banner.html
+++ b/layouts/partials/banner.html
@@ -1,7 +1,7 @@
 <header role="banner" class="container {{ if .IsHome }}front-page-banner{{ else }}page-banner{{ end }} hidden-print" id="headcontainer">
 <a id="skippy" class="sr-only sr-only-focusable" href="#maincontent"><div class="container"><span class="skiplink-text">Skip to main content</span></div></a>
     {{ if .IsHome }}
-    <h1 id="front-page-logo"><img src="{{ .Site.BaseURL }}img/banner-front-logo.png" role="presentation" alt="" itemprop="primaryImageOfPage" /><span class="sr-only" itemprop="name">CompilED:</span><span id="tagline">And Often Interpreted</span></h1>
+    <h1 id="front-page-logo"><img src="{{ .Site.BaseURL }}img/banner-front-logo.png" srcset="{{ .Site.BaseURL }}img/banner-front-logo.png 2x" role="presentation" alt="" itemprop="primaryImageOfPage" /><span class="sr-only" itemprop="name">CompilED:</span><span id="tagline">And Often Interpreted</span></h1>
     {{ else }}
     <h1 class="sr-only"><span itemprop="name">CompilED:</span></h1>
     {{ end }}
@@ -14,7 +14,7 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-          <a class="navbar-brand" href="{{ .Site.BaseURL }}"><img src="{{ .Site.BaseURL }}img/logo-nav.png" alt="Go to CompilED homepage" /></a>
+          <a class="navbar-brand" href="{{ .Site.BaseURL }}"><img src="{{ .Site.BaseURL }}img/logo-nav.png" srcset="{{ .Site.BaseURL}}img/logo-nav.png 2x" alt="Go to CompilED homepage" /></a>
         </div>
         <div id="navbar" class="collapse navbar-collapse">
           <ul class="nav navbar-nav">


### PR DESCRIPTION
This lets us point the header to higher-resolution logos when the
display has higher pixel density, for example at `front-logo@2x.png`.
For now it's just pointing to the existing files.

https://www.smashingmagazine.com/2013/08/webkit-implements-srcset-and-why-its-a-good-thing/