### PR TITLE
PR Pennance

### DIFF
--- a/content/articles/linkdump-2017-02-17.md
+++ b/content/articles/linkdump-2017-02-17.md
@@ -2,7 +2,6 @@
 author_name: "Anders Pearson"
 author_url: http://ctl.columbia.edu/about/team/pearson/
 date: 2017-02-17
-draft: true
 lede: "Friday Linkdump"
 poster: 
 poster_source: ""


### PR DESCRIPTION
The commit in which Nick corrects for his hasty PR merging ways.

This commit removes "draft: true" from the front matter of of this
linkdump, ensuring that it actually gets published.