### PR TITLE
:arrow_up: jquery 2.2.4

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -31,7 +31,7 @@
 </footer>
 
 <!-- Javascript -->
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js" integrity="sha384-0mSbJDEHialfmuBBQP6A4Qrprq5OVfW37PRR3j5ELqxss1yVqOtnepnHVP9aJ7xS" crossorigin="anonymous"></script>
 <script src="{{ .Site.BaseURL }}js/tabindex.js" type="text/javascript"></script>
 <script src="{{ .Site.BaseURL }}js/misc.js" type="text/javascript"></script>


### PR DESCRIPTION
Bootstrap 3 doesn't support jQuery 3, so we need to stay on 2 here.