### PR TITLE
Take off the blue background on range inputs

### DIFF
--- a/content/articles/a-range-input-for-scientific-applications.md
+++ b/content/articles/a-range-input-for-scientific-applications.md
@@ -15,7 +15,7 @@ tags: ["html", "javascript"]
 
 Here's a range input. Notice how it jumps immediately to the position you click:
 
-<div class="alert alert-info"><input type="range"
+<div class="alert"><input type="range"
     step="1"
     min="0"
     max="100"
@@ -37,7 +37,7 @@ down.
 You can make the click event behave in the same way by filtering the
 input's oninput event, like this:
 
-<div class="alert alert-info"><input type="range"
+<div class="alert"><input type="range"
     step="1"
     min="0"
     max="100"


### PR DESCRIPTION
The `alert` is nice because it gives the slider good spacing, but I think the blue background is unnecessary, and makes the slider hard to see depending on your system. On Chrome in Linux, the grey slider kind of blends into the light blue background. Because the range input's styles aren't defined in the HTML spec, some browser could potentially even render it with a clashing blue background. So, it's best to just leave its background empty.

![2018-08-24-115948_614x78_scrot](https://user-images.githubusercontent.com/59292/44594814-37076f80-a795-11e8-8a85-f8d78a402311.png)

vs:

![2018-08-24-115951_623x67_scrot](https://user-images.githubusercontent.com/59292/44594818-3a026000-a795-11e8-940e-60f9121b8a61.png)
