### PR TITLE
Remove unnecessary `console: true` in eslint config

### DIFF
--- a/static/js/src/search.js
+++ b/static/js/src/search.js
@@ -1,4 +1,4 @@
-/* global lunr: true, console: true */
+/* global lunr: true */
 
 var initializeLunrIndex = function(items) {
     return lunr(function() {


### PR DESCRIPTION
This file doesn't use `console`, so we don't need to allow for its use with eslint.