### PR TITLE
Remove poster image empty metadata

### DIFF
--- a/content/articles/planes-in-threejs.md
+++ b/content/articles/planes-in-threejs.md
@@ -6,10 +6,7 @@ author_name:  "Nik Nyby"
 author_url: "https://ctl.columbia.edu/about/team/nyby/"
 lede: "This is an overview for 3D graphics beginners just learning to work with
 Planes, quaternions, and rotations."
-poster: "filename"
 socmediaimg: "socmediaimg-planes-in-threejs.png"
-poster_sourceurl: ""
-poster_source: ""
 topics: 
 - Research and Development
 tags: ["three.js", "graphics"]


### PR DESCRIPTION
This fixes a broken image link problem that Maurice ran into.

![compiled-ss](https://user-images.githubusercontent.com/59292/53913252-e9639d80-4028-11e9-8222-dcd7a5c2d356.png)
